### PR TITLE
Add support for downloading "only_on_web" videos.

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ async def download_video(s: ClientSession, index, path, block):
     name = os.path.join(path, index + "_" + normPath(block["display_name"]))
 
     download_data = []
-    if "transcripts" in block["student_view_data"]:
+    if "transcripts" in block["student_view_data"] and "en" in block["student_view_data"]["transcripts"]:
         download_data.append((block["student_view_data"]["transcripts"]["en"], ".srt"))
 
     if block["student_view_data"]["only_on_web"]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp
 python-dotenv
+beautifulsoup4


### PR DESCRIPTION
Prior to this commit, the edx-download script would crash
with a stack trace when encountering a "only_on_web" video
since those blocks do not contain neither of the keys
'transcript' nor 'encoded_videos'.

To avoid this crash, a check for presence of key was added.

The "only_on_web" videos are presented on HTML pages to the
student and on these pages, a "Download video file" anchor
link is present. The edx-download script was updated to
search for this link using beautifulsoup CSS selectors and
add the link to the download tasks.

As an example of an "only_on_web" video block, consider:

		 "block-v1:HarvardX+MCB80.2x+2T2022+type@video+block@ff6d8db13e214a21b849f70c777e2af5": {
			  "id": "block-v1:HarvardX+MCB80.2x+2T2022+type@video+block@ff6d8db13e214a21b849f70c777e2af5",
			  "block_id": "ff6d8db13e214a21b849f70c777e2af5",
			  "lms_web_url": "https://courses.edx.org/courses/course-v1:HarvardX+MCB80.2x+2T2022/jump_to/block-v1:HarvardX+MCB80.2x+2T2022+type@video+block@ff6d8db13e214a21b849f70c777e2af5",
			  "legacy_web_url": "https://courses.edx.org/courses/course-v1:HarvardX+MCB80.2x+2T2022/jump_to/block-v1:HarvardX+MCB80.2x+2T2022+type@video+block@ff6d8db13e214a21b849f70c777e2af5?experience=legacy",
			  "student_view_url": "https://courses.edx.org/xblock/block-v1:HarvardX+MCB80.2x+2T2022+type@video+block@ff6d8db13e214a21b849f70c777e2af5",
			  "type": "video",
			  "display_name": "The Presynaptic Terminal: Video 5",
			  "graded": true,
			  "student_view_data": {
					"only_on_web": true
			  },
			  "student_view_multi_device": false,
			  "block_counts": {
					"video": 1
			  },
			  "completion": 1.0
		 },